### PR TITLE
Fix command line arguments being ignored

### DIFF
--- a/XivAlexanderLoader/App.cpp
+++ b/XivAlexanderLoader/App.cpp
@@ -154,17 +154,20 @@ int WINAPI wWinMain(
 		bool noask = false;
 		bool noerror = false;
 	} params;
-	int nArgs;
-	LPWSTR *szArgList = CommandLineToArgvW(lpCmdLine, &nArgs);
-	if (nArgs > 1) {
-		for (int i = 1; i < nArgs; i++) {
-			if (wcsncmp(L"/noask", szArgList[i], 6) == 0)
-				params.noask = true;
-			if (wcsncmp(L"/noerror", szArgList[i], 8) == 0)
-				params.noerror = true;
+	
+	if (wcslen(lpCmdLine) > 0) {
+		int nArgs;
+		LPWSTR* szArgList = CommandLineToArgvW(lpCmdLine, &nArgs);
+		if (nArgs > 0) {
+			for (int i = 0; i < nArgs; i++) {
+				if (wcsncmp(L"/noask", szArgList[i], 6) == 0)
+					params.noask = true;
+				if (wcsncmp(L"/noerror", szArgList[i], 8) == 0)
+					params.noerror = true;
+			}
 		}
+		LocalFree(szArgList);
 	}
-	LocalFree(szArgList);
 
 	DWORD pid;
 	HWND hwnd = nullptr;


### PR DESCRIPTION
Currently, the first argument passed to XIVA will be ignored.

Passing no arguments:

![args1](https://user-images.githubusercontent.com/59027738/112726426-50f12c00-8f15-11eb-9931-b4e81b04125b.PNG)

Passing 2 arguments:

![args2](https://user-images.githubusercontent.com/59027738/112726433-5cdcee00-8f15-11eb-85ac-3873faa1f728.PNG)

If we only pass one argument, we will currently not enter the for loop section. If we pass two, we will ignore the first due to `for (int i = 1; i < nArgs;`. I assume the reasoning behind ignoring the first argument is because `szArgsList` appears to contain a path sometimes, but that's under our control:

>[CommandLineToArgvW function (shellapi.h)](https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw)
>lpCmdLine
>Type: LPCWSTR
>Pointer to a null-terminated Unicode string that contains the full command line. **If this parameter is an empty string the function returns the path to the current executable file.**

`lpCmdLine` contains the calling args, if there are any. We can check if there's anything in there before we call CommandLineToArgvW. I assume the previous `nArgs > 1` check was to see if there were arguments in addition to the path - but if such args *are given*, szArgList won't contain the path and therefore an actual argument will be skipped.

Fixes #27 