### PR TITLE
Improve latency correction

### DIFF
--- a/XivAlexander/App_ConfigRepository.h
+++ b/XivAlexander/App_ConfigRepository.h
@@ -113,9 +113,6 @@ namespace App {
 		ConfigItem<bool> UseHighLatencyMitigationLogging{ this, "UseHighLatencyMitigationLogging", true };
 		ConfigItem<bool> ReducePacketDelay{ this, "ReducePacketDelay", true };
 		ConfigItem<bool> UseLatencyCorrection{ this, "UseLatencyCorrection", true };
-		ConfigItem<int> BaseLatencyPenalty{ this, "BaseLatencyPenalty", 1, [](int newValue) {
-			return std::min(60, std::max(1, newValue));
-		} };
 		ConfigItem<bool> UseOpcodeFinder{ this, "UseOpcodeFinder", false };
 		ConfigItem<bool> UseEffectApplicationDelayLogger{ this, "UseEffectApplicationDelayLogger", false };
 		ConfigItem<bool> UseAutoAdjustingExtraDelay{ this, "UseAutoAdjustingExtraDelay", true };

--- a/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
+++ b/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
@@ -187,10 +187,8 @@ public:
 												latencyAdjusted = std::min(latencyAdjusted, latencyMedian + latencyDeviation);
 												delay = std::min(delay, rttMedian + rttDeviation);
 
-												// Correct latency value to server response in cases of extreme values (0 ping or extremely high RTT)
-												const int64_t rttMin = conn.GetMinServerResponseDelay();
-
-												latencyAdjusted = std::max(rttMin - rttDeviation - (latencyAdjusted / 2), latencyAdjusted);
+												// Estimate latency based on server response time if discrepancy from ping is too large.
+												latencyAdjusted = std::max(((delay + rttMedian) / 2) - rttDeviation - (rttDeviation / 2), latencyAdjusted);
 
 												if (latencyAdjusted != latency) {
 													extraMessage += Utils::FormatString(" (%lldms)", latencyAdjusted);

--- a/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
+++ b/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
@@ -190,7 +190,7 @@ public:
 												// Correct latency value to server response in cases of extreme values (0 ping or extremely high RTT)
 												const int64_t rttMin = conn.GetMinServerResponseDelay();
 
-												latencyAdjusted = std::max(rttMin - rttDeviation - latencyAdjusted, latencyAdjusted);
+												latencyAdjusted = std::max(rttMin - rttDeviation - (latencyAdjusted / 2), latencyAdjusted);
 
 												if (latencyAdjusted != latency) {
 													extraMessage += Utils::FormatString(" (%lldms)", latencyAdjusted);

--- a/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
+++ b/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
@@ -192,7 +192,7 @@ public:
 
 												extraMessage += Utils::FormatString(" (%lldms)", latencyEstimate);
 
-												// Correct latency value if discrepancy is detected.
+												// Correct latency value based on estimate if server response time is stable.
 												latencyAdjusted = std::max(latencyEstimate, latencyAdjusted);
 											}
 

--- a/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
+++ b/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
@@ -188,20 +188,11 @@ public:
 												delay = std::min(delay, rttMedian + rttDeviation);
 
 												// Estimate latency based on server response time if discrepancy from ping is too large.
-												latencyAdjusted = std::max(((delay + rttMedian) / 2) - rttDeviation - (rttDeviation / 2), latencyAdjusted);
+												latencyAdjusted = std::max(((rtt + delay + rttMedian) / 3) - rttDeviation - (rttDeviation / 2), latencyAdjusted);
 
 												if (latencyAdjusted != latency) {
 													extraMessage += Utils::FormatString(" (%lldms)", latencyAdjusted);
 												}
-
-												// Calculate penalty from standard deviation of ping or using BaseLatencyPenalty
-												// If user's ping is lower than the setting, simulate their expected ping from observed statistics.
-												const int64_t latencyBase = std::min(static_cast<int64_t>(config.BaseLatencyPenalty) - latencyDeviation, latencyMedian + latencyDeviation);
-												const int64_t penalty = std::max(latencyBase, latencyDeviation) / 2;
-
-												// Adjust latency value to add a one-way safety buffer using penalty value.
-												latencyAdjusted = std::max(penalty, latencyAdjusted - penalty);
-												extraMessage += Utils::FormatString(" penalty=%lldms", penalty);
 											}
 
 											// This delay is based on server's processing time. If the server is busy, everyone should feel the same effect.

--- a/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
+++ b/XivAlexander/App_Feature_AnimationLockLatencyHandler.cpp
@@ -187,6 +187,15 @@ public:
 												latencyAdjusted = std::min(latencyAdjusted, latencyMedian + latencyDeviation);
 												delay = std::min(delay, rttMedian + rttDeviation);
 
+												// Correct latency value to server response in cases of extreme values (0 ping or extremely high RTT)
+												const int64_t rttMin = conn.GetMinServerResponseDelay();
+
+												latencyAdjusted = std::max(rttMin - rttDeviation - latencyAdjusted, latencyAdjusted);
+
+												if (latencyAdjusted != latency) {
+													extraMessage += Utils::FormatString(" (%lldms)", latencyAdjusted);
+												}
+
 												// Calculate penalty from standard deviation of ping or using BaseLatencyPenalty
 												// If user's ping is lower than the setting, simulate their expected ping from observed statistics.
 												const int64_t latencyBase = std::min(static_cast<int64_t>(config.BaseLatencyPenalty) - latencyDeviation, latencyMedian + latencyDeviation);

--- a/XivAlexander/App_Network_SocketHook.cpp
+++ b/XivAlexander/App_Network_SocketHook.cpp
@@ -313,6 +313,20 @@ public:
 			m_observedServerResponseList.erase(m_observedServerResponseList.begin());
 	}
 
+	int64_t GetMinServerResponseDelay() const {
+		if (m_observedServerResponseList.empty())
+			return 0;
+
+		return *std::min_element(m_observedServerResponseList.begin(), m_observedServerResponseList.end());
+	}
+
+	int64_t GetMaxServerResponseDelay() const {
+		if (m_observedServerResponseList.empty())
+			return 0;
+
+		return *std::max_element(m_observedServerResponseList.begin(), m_observedServerResponseList.end());
+	}
+
 	int64_t GetMeanServerResponseDelay() const {
 		if (m_observedServerResponseList.empty())
 			return 0;
@@ -547,6 +561,14 @@ int64_t App::Network::SingleConnection::GetConnectionLatencyDeviation() const {
 
 void App::Network::SingleConnection::AddServerResponseDelayItem(uint64_t delay) {
 	return impl->AddServerResponseDelayItem(delay);
+}
+
+int64_t App::Network::SingleConnection::GetMinServerResponseDelay() const {
+	return impl->GetMinServerResponseDelay();
+}
+
+int64_t App::Network::SingleConnection::GetMaxServerResponseDelay() const {
+	return impl->GetMaxServerResponseDelay();
 }
 
 int64_t App::Network::SingleConnection::GetMeanServerResponseDelay() const {

--- a/XivAlexander/App_Network_SocketHook.cpp
+++ b/XivAlexander/App_Network_SocketHook.cpp
@@ -250,7 +250,7 @@ public:
 			m_nIoctlTcpInfoFailureCount++;
 			return 0;
 		} else {
-			return std::max(1LL, info.RttUs / 1000LL);
+			return (info.RttUs / 1000LL);
 		}
 	}
 

--- a/XivAlexander/App_Network_SocketHook.cpp
+++ b/XivAlexander/App_Network_SocketHook.cpp
@@ -250,7 +250,7 @@ public:
 			m_nIoctlTcpInfoFailureCount++;
 			return 0;
 		} else {
-			return (info.RttUs / 1000LL);
+			return std::max(1LL, info.RttUs / 1000LL);
 		}
 	}
 
@@ -311,20 +311,6 @@ public:
 
 		if (m_observedServerResponseList.size() > latencyTrackCount)
 			m_observedServerResponseList.erase(m_observedServerResponseList.begin());
-	}
-
-	int64_t GetMinServerResponseDelay() const {
-		if (m_observedServerResponseList.empty())
-			return 0;
-
-		return *std::min_element(m_observedServerResponseList.begin(), m_observedServerResponseList.end());
-	}
-
-	int64_t GetMaxServerResponseDelay() const {
-		if (m_observedServerResponseList.empty())
-			return 0;
-
-		return *std::max_element(m_observedServerResponseList.begin(), m_observedServerResponseList.end());
 	}
 
 	int64_t GetMeanServerResponseDelay() const {
@@ -561,14 +547,6 @@ int64_t App::Network::SingleConnection::GetConnectionLatencyDeviation() const {
 
 void App::Network::SingleConnection::AddServerResponseDelayItem(uint64_t delay) {
 	return impl->AddServerResponseDelayItem(delay);
-}
-
-int64_t App::Network::SingleConnection::GetMinServerResponseDelay() const {
-	return impl->GetMinServerResponseDelay();
-}
-
-int64_t App::Network::SingleConnection::GetMaxServerResponseDelay() const {
-	return impl->GetMaxServerResponseDelay();
 }
 
 int64_t App::Network::SingleConnection::GetMeanServerResponseDelay() const {

--- a/XivAlexander/App_Network_SocketHook.cpp
+++ b/XivAlexander/App_Network_SocketHook.cpp
@@ -313,6 +313,13 @@ public:
 			m_observedServerResponseList.erase(m_observedServerResponseList.begin());
 	}
 
+	int64_t GetMinServerResponseDelay() const {
+		if (m_observedServerResponseList.empty())
+			return 0;
+
+		return *std::min_element(m_observedServerResponseList.begin(), m_observedServerResponseList.end());
+	}
+
 	int64_t GetMeanServerResponseDelay() const {
 		if (m_observedServerResponseList.empty())
 			return 0;
@@ -547,6 +554,10 @@ int64_t App::Network::SingleConnection::GetConnectionLatencyDeviation() const {
 
 void App::Network::SingleConnection::AddServerResponseDelayItem(uint64_t delay) {
 	return impl->AddServerResponseDelayItem(delay);
+}
+
+int64_t App::Network::SingleConnection::GetMinServerResponseDelay() const {
+	return impl->GetMinServerResponseDelay();
 }
 
 int64_t App::Network::SingleConnection::GetMeanServerResponseDelay() const {

--- a/XivAlexander/App_Network_SocketHook.h
+++ b/XivAlexander/App_Network_SocketHook.h
@@ -28,6 +28,7 @@ namespace App::Network {
 		int64_t GetMeanConnectionLatency() const;
 		int64_t GetConnectionLatencyDeviation() const;
 		void AddServerResponseDelayItem(uint64_t delay);
+		int64_t GetMinServerResponseDelay() const;
 		int64_t GetMeanServerResponseDelay() const;
 		int64_t GetMedianServerResponseDelay() const;
 		int64_t GetServerResponseDelayDeviation() const;

--- a/XivAlexander/App_Network_SocketHook.h
+++ b/XivAlexander/App_Network_SocketHook.h
@@ -28,6 +28,8 @@ namespace App::Network {
 		int64_t GetMeanConnectionLatency() const;
 		int64_t GetConnectionLatencyDeviation() const;
 		void AddServerResponseDelayItem(uint64_t delay);
+		int64_t GetMinServerResponseDelay() const;
+		int64_t GetMaxServerResponseDelay() const;
 		int64_t GetMeanServerResponseDelay() const;
 		int64_t GetMedianServerResponseDelay() const;
 		int64_t GetServerResponseDelayDeviation() const;

--- a/XivAlexander/App_Network_SocketHook.h
+++ b/XivAlexander/App_Network_SocketHook.h
@@ -28,8 +28,6 @@ namespace App::Network {
 		int64_t GetMeanConnectionLatency() const;
 		int64_t GetConnectionLatencyDeviation() const;
 		void AddServerResponseDelayItem(uint64_t delay);
-		int64_t GetMinServerResponseDelay() const;
-		int64_t GetMaxServerResponseDelay() const;
 		int64_t GetMeanServerResponseDelay() const;
 		int64_t GetMedianServerResponseDelay() const;
 		int64_t GetServerResponseDelayDeviation() const;


### PR DESCRIPTION
This change to the latency correction feature will better handle discrepancies in ping to server response time by estimating the latency value based on server response time statistics. Fake ping VPN users will benefit from this change, but having real ping will still be better. For all users, consistency is improved.

Latency estimation will occur depending on these factors:
- Stability of server response time (deviation value)
- Difference of measured ping vs server response time after correcting any sharp spikes

For testing on my end, I artificially increased my server RTT by leaving a download running in the background - meanwhile my ping remains the same. This is most likely a result of packet congestion, which ping does not reflect accurately. By estimating latency to the server based on server response time statistics, packet congestion is factored out.

Penalty calculation (and `BaseLatencyPenalty`) has been removed since it does not improve consistency as originally intended.

TL;DR: Rewrote latency correction so the program does not disadvantage fake VPN users anymore. Also improves consistency and attempts to factor out packet congestion by scaling latency estimation towards server response times.

Fixes #39 