### PR TITLE
Implement Mode 4 - Standard GCD Division

### DIFF
--- a/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
+++ b/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
@@ -393,6 +393,19 @@ struct XivAlexander::Apps::MainApp::Internal::NetworkTimingHandler::Implementati
 					}
 					return lastAnimationLockEndsAtUs + originalWaitUs + delay;
 				}
+
+				case HighLatencyMitigationMode::StandardGcdDivision: {
+					// Calculate new animation lock values based on equal GCD time division by animation lock value.
+					const auto gcdUs = 2500000;
+
+					const auto split = static_cast<int>(std::floor((gcdUs - originalWaitUs) / originalWaitUs));
+					description << std::format(" split={}", split);
+
+					const auto delay = split > 0 ? (gcdUs % originalWaitUs) / split : 0;
+					description << std::format(" delay={}us", delay);
+
+					return nowUs + (originalWaitUs - rttUs) + delay;
+				}
 			}
 
 			description << std::format(" delay={}us", Config->Runtime.ExpectedAnimationLockDurationUs.Value());

--- a/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
+++ b/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
@@ -397,11 +397,13 @@ struct XivAlexander::Apps::MainApp::Internal::NetworkTimingHandler::Implementati
 				case HighLatencyMitigationMode::StandardGcdDivision: {
 					// Calculate new animation lock values based on equal GCD time division by animation lock value.
 					const auto gcdUs = 2500000;
+					const auto gcdWaitUs = 600000;
+					const auto gcdWeaveUs = (gcdUs - gcdWaitUs);
 
-					const auto split = static_cast<int>(std::floor((gcdUs - originalWaitUs) / originalWaitUs));
+					const auto split = static_cast<int>(std::floor(gcdWeaveUs / originalWaitUs));
 					description << std::format(" split={}", split);
 
-					const auto delay = split > 0 ? (gcdUs % originalWaitUs) / split : 0;
+					const auto delay = split > 0 ? (gcdWeaveUs % originalWaitUs) / split : 0;
 					description << std::format(" delay={}us", delay);
 
 					return nowUs + (originalWaitUs - rttUs) + delay;

--- a/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
+++ b/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
@@ -395,14 +395,17 @@ struct XivAlexander::Apps::MainApp::Internal::NetworkTimingHandler::Implementati
 				}
 
 				case HighLatencyMitigationMode::StandardGcdDivision: {
-					// Calculate new animation lock values based on equal GCD time division by animation lock value.
+					// Calculate new animation lock values based on equal slices of a 2.5 GCD.
+					// Assume GCD has 600ms lock time, and remove it from the total GCD time (this will be the weave window).
 					const auto gcdUs = 2500000;
 					const auto gcdWaitUs = 600000;
 					const auto gcdWeaveUs = (gcdUs - gcdWaitUs);
 
+					// Determine how many weaves we can do given the lock time.
 					const auto split = static_cast<int>(std::floor(gcdWeaveUs / originalWaitUs));
 					description << std::format(" split={}", split);
 
+					// Calculate the delay value to add on the original lock time.
 					const auto delay = split > 0 ? (gcdWeaveUs % originalWaitUs) / split : 0;
 					description << std::format(" delay={}us", delay);
 

--- a/XivAlexander/Config.cpp
+++ b/XivAlexander/Config.cpp
@@ -442,6 +442,10 @@ void XivAlexander::to_json(nlohmann::json & j, const HighLatencyMitigationMode &
 		case HighLatencyMitigationMode::SimulateRtt:
 			j = "SimulateRtt";
 			break;
+		
+		case HighLatencyMitigationMode::StandardGcdDivision:
+			j = "StandardGcdDivision";
+			break;
 
 		case HighLatencyMitigationMode::SimulateNormalizedRttAndLatency:
 		default:
@@ -463,6 +467,8 @@ void XivAlexander::from_json(const nlohmann::json & it, HighLatencyMitigationMod
 		value = HighLatencyMitigationMode::SimulateRtt;
 	else if (newValueString.substr(0, std::min<size_t>(16, newValueString.size())) == L"subtractlatency")
 		value = HighLatencyMitigationMode::SubtractLatency;
+	else if (newValueString.substr(0, std::min<size_t>(19, newValueString.size())) == L"standardgcddivision")
+		value = HighLatencyMitigationMode::StandardGcdDivision;
 }
 
 template<typename T>

--- a/XivAlexander/Config.h
+++ b/XivAlexander/Config.h
@@ -19,6 +19,7 @@ namespace XivAlexander {
 		SubtractLatency,
 		SimulateRtt,
 		SimulateNormalizedRttAndLatency,
+		StandardGcdDivision,
 	};
 
 	void to_json(nlohmann::json&, const Language&);


### PR DESCRIPTION
This is a very simple, client-side focused, no-knobs implementation of animation lock mitigation with FFLogs legality intentions. Does not depend on network statistics whatsoever, so effects should be consistent across all clients.

In essence, it rewrites **all** animation lock values from the server in a way that it divides evenly from a 2.5 GCD.

Some notes:
- Triple weaving is possible at 2.5 GCD
- Triple weaving will clip at <2.5 GCD
- Consistency is guaranteed, weave timing is locally deterministic
- Cannot be potentially manipulated by network/response time shenanigans
- It _may_ have a negligible disadvantage over real 0ms ping due to the artificial lock times, but balancing towards safety is probably a good idea

Sorry, I haven't included UI menu items in the commit since it seems there are localizations.