### PR TITLE
Animlock updates and several fixes

### DIFF
--- a/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
+++ b/XivAlexander/Apps/MainApp/Internal/NetworkTimingHandler.cpp
@@ -347,7 +347,7 @@ struct XivAlexander::Apps::MainApp::Internal::NetworkTimingHandler::Implementati
 			// Additionally, obtain estimated latency for use as fallback.
 			const auto rttMinUs = Conn.ApplicationLatencyUs.Min();
 			const auto [rttMeanUs, rttDeviationUs] = Conn.ApplicationLatencyUs.MeanAndDeviation();
-			const auto latencyEstimateUs = ((rttMinUs + rttMeanUs) / 2) - ((rttDeviationUs + 30000) / 2);
+			const auto latencyEstimateUs = ((rttMinUs + rttMeanUs) / 2) - ((rttDeviationUs + 25000) / 2);
 
 			// Replace latency with estimated latency under certain circumstances:
 			// - Failed to obtain measurement
@@ -392,7 +392,7 @@ struct XivAlexander::Apps::MainApp::Internal::NetworkTimingHandler::Implementati
 					// Assume GCD has 600ms lock time, and remove it from the total GCD time (this will be the weave window).
 					const auto gcdUs = 2500000;
 					const auto gcdWaitUs = 600000;
-					const auto gcdWeaveUs = (gcdUs - gcdWaitUs);
+					const auto gcdWeaveUs = (gcdUs - gcdWaitUs) - ((gcdUs % gcdWaitUs) / (static_cast<int>(std::floor(gcdUs / gcdWaitUs))));
 
 					// Determine how many weaves we can do given the lock time.
 					const auto split = static_cast<int>(std::floor(gcdWeaveUs / originalWaitUs));

--- a/XivAlexander/Config.cpp
+++ b/XivAlexander/Config.cpp
@@ -442,6 +442,10 @@ void XivAlexander::to_json(nlohmann::json & j, const HighLatencyMitigationMode &
 		case HighLatencyMitigationMode::SimulateRtt:
 			j = "SimulateRtt";
 			break;
+		
+		case HighLatencyMitigationMode::StandardGcdDivision:
+			j = "StandardGcdDivision";
+			break;
 
 		case HighLatencyMitigationMode::SimulateNormalizedRttAndLatency:
 		default:
@@ -463,6 +467,8 @@ void XivAlexander::from_json(const nlohmann::json & it, HighLatencyMitigationMod
 		value = HighLatencyMitigationMode::SimulateRtt;
 	else if (newValueString.substr(0, std::min<size_t>(16, newValueString.size())) == L"subtractlatency")
 		value = HighLatencyMitigationMode::SubtractLatency;
+	else if (newValueString.substr(0, std::min<size_t>(19, newValueString.size())) == L"standardgcddivision")
+		value = HighLatencyMitigationMode::StandardGcdDivision;
 }
 
 template<typename T>

--- a/XivAlexander/Config.h
+++ b/XivAlexander/Config.h
@@ -19,6 +19,7 @@ namespace XivAlexander {
 		SubtractLatency,
 		SimulateRtt,
 		SimulateNormalizedRttAndLatency,
+		StandardGcdDivision,
 	};
 
 	void to_json(nlohmann::json&, const Language&);

--- a/XivAlexanderCommon/Utils/NumericStatisticsTracker.cpp
+++ b/XivAlexanderCommon/Utils/NumericStatisticsTracker.cpp
@@ -48,7 +48,7 @@ int64_t Utils::NumericStatisticsTracker::Min(int64_t sinceUs) const {
 	for (const auto& v : std::ranges::reverse_view(vals)) {
 		if (v.TimestampUs < sinceUs)
 			break;
-		if (!found || minValue < v.Value)
+		if (!found || minValue > v.Value)
 			minValue = v.Value;
 		found = true;
 	}
@@ -62,7 +62,7 @@ int64_t Utils::NumericStatisticsTracker::Max(int64_t sinceUs) const {
 	for (const auto& v : std::ranges::reverse_view(vals)) {
 		if (v.TimestampUs < sinceUs)
 			break;
-		if (!found || maxValue > v.Value)
+		if (!found || maxValue < v.Value)
 			maxValue = v.Value;
 		found = true;
 	}


### PR DESCRIPTION
This PR improves the animation lock calculation function.

- refactored code for improved readability and organization
- improved mode 3, notably latency estimation and delay calculation (fixes #374, #324, #315)
- **fixed min/max functions from statistics utility** (fixes #415)
- prefer using TCP latency, falling back to ICMP and then estimation. (fixes #341)
- implement mode 4 (no UI entries, but can be set in config manually) as another mitigation mode
- simplify logging output

@Soreepeong please consider this PR with reasonable priority, as there are several reports of Mode 3 causing 0.53s primarily due to the bolded issue fixed noted above. My own further updates for Mode 3 improve upon consistency/safety issues.

Compiled drop-in version with these PR changes is available on my fork, tracking upstream.